### PR TITLE
Fix quality statistics link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ tar -zxvf ../parser.tar.gz
 ### Quality
 We have made some modification to our test data set to improve variations of address and test for improvements we made in this version.  It now has 12951 addresses from 89 countries.
 The over all parsing accuracy improved by 1.09%.  We had improved statistics for 33 countries and had regression with 10.
-You can find statistical comparison of the tests [here](./files/stats/v1.1.0/Parsing_comparison_v1_0_0.md).
+You can find statistical comparison of the tests [here](./files/stats/v1.1.0/Parsing_comparison_v1_1_0.md).
 The bulk of the test data we used is located [here](./files/tests/v1.1.0/test_data.csv). We removed about 100 records from the test set, because we don't have permissions to publish them.
 
 ### Training data


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

Issue number: #20 

## Why was change needed

When the quality statistics link is clicked we get 404 error.

## What does change improve

Fixes the link.
